### PR TITLE
Add register and deprecated on

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,4 @@
 node_modules/
 bower_components/
 .idea/
-.tern-port
+coverage/

--- a/sample/recipes/app.js
+++ b/sample/recipes/app.js
@@ -128,7 +128,7 @@ define([
                 doc = options.doc;
 
             var route = my.router.addRoute({ pattern: options.pattern, name: options.name});
-            route.onMatched(function(result) {
+            route.matched.register(function(result) {
                 if(options.action) {
                     options.action.apply(my.router, [doc].concat(result.getActionArguments()));
                 }

--- a/src/events.js
+++ b/src/events.js
@@ -11,11 +11,11 @@ define([], function() {
 	function event(spec, my) {
 		my = my || {};
 
-		// DEPRECATED: use that.on() instead.
+		// DEPRECATED: use that.register() instead.
 		function that(callback) {
 			// eslint-disable-next-line no-console
-			console.warn("Using an event as a function is deprecated. Send on() to the event instead.");
-			return bindCallback(callback);
+			console.warn("Using an event as a function is deprecated. Send register() to the event instead.");
+			return that.register(callback);
 		}
 
 		var bindings = [];
@@ -25,10 +25,23 @@ define([], function() {
 		/**
 		 * Binds callback to event. The callback will be invoked whenever the event is fired.
 		 *
+		 * @deprecated use that.register() instead.
 		 * @param callback {function}
 		 * @returns {eventBinding}
 		 */
 		that.on = function(callback) {
+			// eslint-disable-next-line no-console
+			console.warn("Sending on() to an event is deprecated. Send register() instead.");
+			return that.register(callback);
+		};
+
+		/**
+		 * Binds callback to event. The callback will be invoked whenever the event is fired.
+		 *
+		 * @param callback {function}
+		 * @returns {eventBinding}
+		 */
+		that.register = function(callback) {
 			return bindCallback(callback);
 		};
 
@@ -60,7 +73,7 @@ define([], function() {
 			 */
 			that.unbind = function() {
 				if (that.isBound()) {
-					event.off(that);
+					event.unregister(that);
 					event = undefined;
 				}
 			};
@@ -91,10 +104,23 @@ define([], function() {
 		/**
 		 * Like on() except callback will only be fired once
 		 *
+		 * @deprecated use registerOnce() instead
 		 * @param callback {function}
 		 * @returns {eventBinding}
 		 */
 		that.onceOn = function(callback) {
+			// eslint-disable-next-line no-console
+			console.warn("Sending onceOn() to an event is deprecated. Send registerOnce() instead.");
+			return that.registerOnce(callback);
+		};
+
+		/**
+		 * Like on() except callback will only be fired once
+		 *
+		 * @param callback {function}
+		 * @returns {eventBinding}
+		 */
+		that.registerOnce = function(callback) {
 			var onceBinding = eventBinding({
 				callback: function() {
 					my.remove(onceBinding);
@@ -108,10 +134,22 @@ define([], function() {
 
 		/**
 		 * Removed "binding" attached to event.
+		 * @deprecated use unregister() instead
 		 * @param name {String} Name of event
 		 * @param binding {eventBinding} Binding
 		 */
 		that.off = function(binding) {
+			// eslint-disable-next-line no-console
+			console.warn("Sending off() to an event is deprecated. Send unregister() instead.");
+			that.unregister(binding);
+		};
+
+		/**
+		 * Removed "binding" attached to event.
+		 * @param name {String} Name of event
+		 * @param binding {eventBinding} Binding
+		 */
+		that.unregister = function(binding) {
 			my.remove(binding);
 		};
 
@@ -204,11 +242,36 @@ define([], function() {
 		/**
 		 * Binds callback to a named event. The callback will be invoked whenever the event is fired.
 		 *
+		 * @deprecated use register() instead
 		 * @param name {String}
 		 * @param callback {function}
 		 */
 		that.on = function(name, callback) {
-			return ensureEventHolderFor(name).on(callback);
+			// eslint-disable-next-line no-console
+			console.warn("Sending on() to a category is deprecated. Send register() instead.");
+			return that.register(name, callback);
+		};
+
+		/**
+		 * Binds callback to a named event. The callback will be invoked whenever the event is fired.
+		 *
+		 * @param name {String}
+		 * @param callback {function}
+		 */
+		that.register = function(name, callback) {
+			return ensureEventHolderFor(name).register(callback);
+		};
+
+		/**
+		 * Removed "binding" attached to event.
+		 * @deprecated use unregister() instead
+		 * @param name {String} Name of event
+		 * @param binding {eventBinding} Binding
+		 */
+		that.off = function(name, binding) {
+			// eslint-disable-next-line no-console
+			console.warn("Sending off() to a category is deprecated. Send unregister() instead.");
+			return that.unregister(name, binding);
 		};
 
 		/**
@@ -216,8 +279,22 @@ define([], function() {
 		 * @param name {String} Name of event
 		 * @param binding {eventBinding} Binding
 		 */
-		that.off = function(name, binding) {
-			return ensureEventHolderFor(name).off(binding);
+		that.unregister = function(name, binding) {
+			return ensureEventHolderFor(name).unregister(binding);
+		};
+
+		/**
+		 * Like on() except callback will only be fired once
+		 *
+		 * @deprecated use registerOnce() instead
+		 * @param name
+		 * @param callback
+		 * @returns {*}
+		 */
+		that.onceOn = function(name, callback) {
+			// eslint-disable-next-line no-console
+			console.warn("Sending onceOn() to a category is deprecated. Send registerOnce() instead.");
+			return that.registerOnce(name, callback);
 		};
 
 		/**
@@ -227,8 +304,8 @@ define([], function() {
 		 * @param callback
 		 * @returns {*}
 		 */
-		that.onceOn = function(name, callback) {
-			return ensureEventHolderFor(name).onceOn(callback);
+		that.registerOnce = function(name, callback) {
+			return ensureEventHolderFor(name).registerOnce(callback);
 		};
 
 		/**

--- a/src/router/hashLocation.js
+++ b/src/router/hashLocation.js
@@ -50,7 +50,8 @@ define([
 		 *
 		 * @type {event}
 		 */
-		that.onChanged = my.events.createEvent("changed");
+		that.changed = my.events.createEvent("changed");
+		that.onChanged = that.changed; // deprecated
 
 		/**
 		 * Set hash fragment to URL
@@ -167,7 +168,7 @@ define([
 				my.history.push(my.currentHash);
 			}
 
-			that.onChanged.trigger(urlFromHash(my.currentHash));
+			that.changed.trigger(urlFromHash(my.currentHash));
 		}
 
 		function check() {

--- a/src/router/route.js
+++ b/src/router/route.js
@@ -92,7 +92,7 @@ define([
 		that.onMatched = that.matched; // deprecated
 
 		// @deprecated Use event property instead
-		that.on = my.events.on;
+		that.on = my.events.register;
 
 		/**
 		 * Match route against URL by comparing segments. Triggers

--- a/src/router/route.js
+++ b/src/router/route.js
@@ -88,14 +88,15 @@ define([
 		// Public
 		//
 
-		that.onMatched = my.events.createEvent("matched");
+		that.matched = my.events.createEvent("matched");
+		that.onMatched = that.matched; // deprecated
 
 		// @deprecated Use event property instead
 		that.on = my.events.on;
 
 		/**
 		 * Match route against URL by comparing segments. Triggers
-		 * `onMatched` event on match.
+		 * `matched` event on match.
 		 *
 		 * @param {url} url
 		 * @returns {routeMatchResult}

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -45,7 +45,7 @@ define([
 			my.defaultParameters = {};
 
 			// Listen for URL changes and resolve URL when changed
-			my.location.onChanged(function() { my.resolveUrl(); });
+			my.location.changed.register(function() { my.resolveUrl(); });
 		};
 
 		// Events

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -59,7 +59,8 @@ define([
 		 * Triggered when a route is matched with `routeMatchResult` as argument.
 		 * @type {event}
 		 */
-		that.onRouteMatched = my.events.createEvent("routeMatched");
+		that.routeMatched = my.events.createEvent("routeMatched");
+		that.onRouteMatched = that.routeMatched; // deprecated
 
 		/**
 		 * Triggered when a route is not matched with "url" as argument.
@@ -536,7 +537,7 @@ define([
 				if (result.isMatch()) {
 					my.lastMatch = result;
 					numMatched++;
-					that.onRouteMatched.trigger(result);
+					that.routeMatched.trigger(result);
 
 					if (candidateRoute.fallThrough === undefined ||
 						candidateRoute.fallThrough === false) {

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -65,7 +65,8 @@ define([
 		 * Triggered when a route is not matched with "url" as argument.
 		 * @type {event}
 		 */
-		that.onRouteNotFound = my.events.createEvent("routeNotFound");
+		that.routeNotFound = my.events.createEvent("routeNotFound");
+		that.onRouteNotFound = that.routeNotFound; // deprecated
 
 		/**
 		 * Triggered each time a URL is resolved with `url` as argument
@@ -247,7 +248,7 @@ define([
 		 * @returns {route}
 		 */
 		that.pipeNotFound = function(router) {
-			return that.onRouteNotFound(function(aRawUrl) {
+			return that.routeNotFound.register(function(aRawUrl) {
 				router.resolveUrl(aRawUrl);
 			});
 		};
@@ -546,7 +547,7 @@ define([
 			});
 
 			if (numMatched === 0) {
-				that.onRouteNotFound.trigger(currentUrl.toString());
+				that.routeNotFound.trigger(currentUrl.toString());
 			}
 		};
 

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -76,7 +76,7 @@ define([
 		that.onResolveUrl = my.events.createEvent("resolveUrl");
 
 		// @deprecated Use event property instead
-		that.on = my.events.on;
+		that.on = my.events.register;
 
 		//
 		// Public

--- a/src/router/router.js
+++ b/src/router/router.js
@@ -116,9 +116,9 @@ define([
 			 *			action: function(id) { console.log(id);},
 			 *		});
 		 *
-		 *        // Route with only pattern and custom onMatched event handler,
+		 *        // Route with only pattern and custom matched event handler,
 		 *        var route = aRouter.addRoute({ pattern: ""/user/#id""});
-		 *        route.onMatched(function(result) {
+		 *        route.matched.register(function(result) {
 			 *			console.dir(result.getValues());
 			 *		});
 		 *
@@ -152,7 +152,7 @@ define([
 			});
 
 			if (routeSpec.action) {
-				newRoute.onMatched(function(result) {
+				newRoute.matched.register(function(result) {
 					routeSpec.action.apply(this, result.getActionArguments());
 				});
 			}
@@ -233,7 +233,7 @@ define([
 			}
 
 			var aRoute = that.addRoute(routeSpec);
-			aRoute.onMatched(function(result) {
+			aRoute.matched.register(function(result) {
 				router.resolveUrl(result.getUrl());
 			});
 

--- a/src/widget.js
+++ b/src/widget.js
@@ -272,10 +272,15 @@ define([
 			names.forEach(my.createEvent);
 		};
 
-		// Expose events
+		// deprecated, please use the ones below instead
 		that.on = my.events.on;
 		that.onceOn = my.events.onceOn;
 		that.off = my.events.off;
+
+		// Expose events
+		that.register = my.events.register;
+		that.registerOnce = my.events.registerOnce;
+		that.unregister = my.events.unregister;
 		that.trigger = my.events.trigger;
 
 		//

--- a/test/eventsTest.js
+++ b/test/eventsTest.js
@@ -4,110 +4,107 @@ define(["src/events"], function(events) {
 		it("Bind callback to event", function() {
 			// Arrange: an event
 			var anEvent = events.event();
+			var spy = jasmine.createSpy("callback");
 
 			// Act: bind a callback
-			anEvent(function() {
-				expect(true).toBeTruthy();
-			});
+			anEvent(spy);
 
 			// and execute
 			anEvent.trigger();
+
+			// Assert
+			expect(spy).toHaveBeenCalled();
 		});
 
 		it("Bind multiple callbacks to an event", function() {
 			// Arrange: an event
 			var anEvent = events.event();
+			var spy = jasmine.createSpy("callback");
 
 			// Act: bind two callbacks and trigger event
-			var counter = 0;
-			anEvent(function() { counter++;});
-			anEvent(function() { counter++;});
+			anEvent(spy);
+			anEvent(spy);
 
 			anEvent.trigger();
 
 			// Assert: that both where executed
-			expect(counter).toBe(2);
+			expect(spy).toHaveBeenCalledTimes(2);
 		});
 
 		it("Trigger pass values to callbacks", function() {
 			// Arrange: an event
 			var anEvent = events.event();
+			var spy1 = jasmine.createSpy("callback1");
+			var spy2 = jasmine.createSpy("callback2");
 
 			// Act: bind two callbacks and trigger event
-			var counter = 0;
-			anEvent(function(num, str) {
-				expect(num).toBe(2);
-				expect(str).toBe("text");
-				counter++;
-			});
-			anEvent(function() {
-				expect(arguments.length).toBe(2);
-				counter++;
-			});
+			anEvent(spy1);
+			anEvent(spy2);
 
 			anEvent.trigger(2, "text");
 
 			// Assert: that both where executed
-			expect(counter).toBe(2);
+			expect(spy1).toHaveBeenCalledWith(2, "text");
+			expect(spy2).toHaveBeenCalledWith(2, "text");
 		});
 
 		it("Bind callback to event using on", function() {
 			// Arrange: an event
 			var anEvent = events.event();
+			var spy = jasmine.createSpy("callback");
 
 			// bind a callback using on
-			anEvent.on(function() {
-				expect(true).toBeTruthy();
-			});
+			anEvent.on(spy);
 
 			anEvent.trigger();
+
+			expect(spy).toHaveBeenCalled();
 		});
 
 		it("Un-Bind callback using off", function() {
 			// Arrange: an event
 			var anEvent = events.event();
+			var spy = jasmine.createSpy("callback");
 
 			// bind a callback using on
-			var eventBinding = anEvent.on(function() {
-				jasmine.fail();
-			});
+			var eventBinding = anEvent.on(spy);
 
 			// unbind using off
 			anEvent.off(eventBinding);
 
 			anEvent.trigger();
+
+			expect(spy).not.toHaveBeenCalled();
 		});
 
 		it("Un-Bind callback using unbind", function() {
 			// Arrange: an event
 			var anEvent = events.event();
+			var spy = jasmine.createSpy("callback");
 
 			// bind a callback using on
-			var eventBinding = anEvent.on(function() {
-				jasmine.fail();
-			});
+			var eventBinding = anEvent.on(spy);
 
 			// Unbind
 			eventBinding.unbind();
 
 			anEvent.trigger();
+			expect(spy).not.toHaveBeenCalled();
 		});
 
 		it("Bind and trigger callback only once using onceOn", function() {
 			// Arrange: an event
 			var anEvent = events.event();
+			var spy = jasmine.createSpy("callback");
 
 			// Act: bind a callback using on
-			var counter = 0;
-			anEvent.onceOn(function() {
-				counter++;
-			});
+			anEvent.onceOn(spy);
 
 			// and trigger twice
 			anEvent.trigger();
 			anEvent.trigger();
 
-			expect(counter).toBe(1);
+			expect(spy).toHaveBeenCalledTimes(1);
 		});
 
 		it("Event dispose unbinds all callbacks", function() {
@@ -163,34 +160,32 @@ define(["src/events"], function(events) {
 			// Arrange: an event
 			var someEvents = events.eventCategory();
 			var anEvent = someEvents.createEvent("namedEvent");
+			var spy = jasmine.createSpy("callback");
 
 			// bind a callback using on
-			var eventBinding = someEvents.on("namedEvent", function() {
-				expect(true).toBeFalsy();
-			});
+			var eventBinding = someEvents.on("namedEvent", spy);
 
 			// unbind using off
 			someEvents.off("namedEvent", eventBinding);
 
 			anEvent.trigger("namedEvent");
+			expect(spy).not.toHaveBeenCalled();
 		});
 
 		it("Event Category can bind and trigger named event callback only once using onceOn", function() {
 			// Arrange: an event
 			var someEvents = events.eventCategory();
 			var anEvent = someEvents.createEvent("namedEvent");
+			var spy = jasmine.createSpy("callback");
 
-			// Act: bind a callback using on
-			var counter = 0;
-			someEvents.onceOn("namedEvent", function() {
-				counter++;
-			});
+			// Act: bind a callback
+			someEvents.onceOn("namedEvent", spy);
 
 			// and trigger twice
 			anEvent.trigger("namedEvent");
 			anEvent.trigger("namedEvent");
 
-			expect(counter).toBe(1);
+			expect(spy).toHaveBeenCalledTimes(1);
 		});
 
 		it("Event Category can bind dispose unbinds all events and there callbacks", function() {

--- a/test/eventsTest.js
+++ b/test/eventsTest.js
@@ -7,7 +7,7 @@ define(["src/events"], function(events) {
 			var spy = jasmine.createSpy("callback");
 
 			// Act: bind a callback
-			anEvent(spy);
+			anEvent.register(spy);
 
 			// and execute
 			anEvent.trigger();
@@ -22,8 +22,8 @@ define(["src/events"], function(events) {
 			var spy = jasmine.createSpy("callback");
 
 			// Act: bind two callbacks and trigger event
-			anEvent(spy);
-			anEvent(spy);
+			anEvent.register(spy);
+			anEvent.register(spy);
 
 			anEvent.trigger();
 
@@ -38,8 +38,8 @@ define(["src/events"], function(events) {
 			var spy2 = jasmine.createSpy("callback2");
 
 			// Act: bind two callbacks and trigger event
-			anEvent(spy1);
-			anEvent(spy2);
+			anEvent.register(spy1);
+			anEvent.register(spy2);
 
 			anEvent.trigger(2, "text");
 
@@ -48,29 +48,16 @@ define(["src/events"], function(events) {
 			expect(spy2).toHaveBeenCalledWith(2, "text");
 		});
 
-		it("Bind callback to event using on", function() {
+		it("Un-Bind callback using unregister", function() {
 			// Arrange: an event
 			var anEvent = events.event();
 			var spy = jasmine.createSpy("callback");
 
-			// bind a callback using on
-			anEvent.on(spy);
+			// bind a callback
+			var eventBinding = anEvent.register(spy);
 
-			anEvent.trigger();
-
-			expect(spy).toHaveBeenCalled();
-		});
-
-		it("Un-Bind callback using off", function() {
-			// Arrange: an event
-			var anEvent = events.event();
-			var spy = jasmine.createSpy("callback");
-
-			// bind a callback using on
-			var eventBinding = anEvent.on(spy);
-
-			// unbind using off
-			anEvent.off(eventBinding);
+			// unbind
+			anEvent.unregister(eventBinding);
 
 			anEvent.trigger();
 
@@ -82,8 +69,8 @@ define(["src/events"], function(events) {
 			var anEvent = events.event();
 			var spy = jasmine.createSpy("callback");
 
-			// bind a callback using on
-			var eventBinding = anEvent.on(spy);
+			// bind a callback
+			var eventBinding = anEvent.register(spy);
 
 			// Unbind
 			eventBinding.unbind();
@@ -92,13 +79,13 @@ define(["src/events"], function(events) {
 			expect(spy).not.toHaveBeenCalled();
 		});
 
-		it("Bind and trigger callback only once using onceOn", function() {
+		it("Bind and trigger callback only once using registerOnce", function() {
 			// Arrange: an event
 			var anEvent = events.event();
 			var spy = jasmine.createSpy("callback");
 
-			// Act: bind a callback using on
-			anEvent.onceOn(spy);
+			// Act: bind a callback
+			anEvent.registerOnce(spy);
 
 			// and trigger twice
 			anEvent.trigger();
@@ -112,8 +99,8 @@ define(["src/events"], function(events) {
 			var anEvent = events.event();
 
 			// Act: bind two callbacks and trigger event
-			var firstBinding = anEvent(function() {});
-			var secondBinding = anEvent(function() {});
+			var firstBinding = anEvent.register(function() {});
+			var secondBinding = anEvent.register(function() {});
 
 			anEvent.dispose();
 
@@ -142,13 +129,13 @@ define(["src/events"], function(events) {
 			expect(anEvent.on).toBeTruthy();
 		});
 
-		it("Event Category can bind callback to named event using on", function() {
+		it("Event Category can bind callback to named event using register", function() {
 			// Arrange: an event
 			var someEvents = events.eventCategory();
 			var anEvent = someEvents.createEvent("namedEvent");
 
-			// bind a callback using on
-			someEvents.on("namedEvent", function() {
+			// bind a callback
+			someEvents.register("namedEvent", function() {
 				expect(true).toBeTruthy();
 			});
 
@@ -156,30 +143,30 @@ define(["src/events"], function(events) {
 			anEvent.trigger("namedEvent");
 		});
 
-		it("Event Category can un-bind named event callbacks using off", function() {
+		it("Event Category can un-bind named event callbacks using unregister", function() {
 			// Arrange: an event
 			var someEvents = events.eventCategory();
 			var anEvent = someEvents.createEvent("namedEvent");
 			var spy = jasmine.createSpy("callback");
 
-			// bind a callback using on
-			var eventBinding = someEvents.on("namedEvent", spy);
+			// bind a callback
+			var eventBinding = someEvents.register("namedEvent", spy);
 
-			// unbind using off
-			someEvents.off("namedEvent", eventBinding);
+			// unbind
+			someEvents.unregister("namedEvent", eventBinding);
 
 			anEvent.trigger("namedEvent");
 			expect(spy).not.toHaveBeenCalled();
 		});
 
-		it("Event Category can bind and trigger named event callback only once using onceOn", function() {
+		it("Event Category can bind and trigger named event callback only once using registerOnce", function() {
 			// Arrange: an event
 			var someEvents = events.eventCategory();
 			var anEvent = someEvents.createEvent("namedEvent");
 			var spy = jasmine.createSpy("callback");
 
 			// Act: bind a callback
-			someEvents.onceOn("namedEvent", spy);
+			someEvents.registerOnce("namedEvent", spy);
 
 			// and trigger twice
 			anEvent.trigger("namedEvent");
@@ -195,10 +182,10 @@ define(["src/events"], function(events) {
 			var anotherEvent = someEvents.createEvent("namedEvent");
 
 			// Act: bind two callbacks and trigger event
-			var firstBinding = anEvent(function() {});
-			var secondBinding = anEvent(function() {});
-			var thirdBinding = anotherEvent(function() {});
-			var fourthBinding = anotherEvent(function() {});
+			var firstBinding = anEvent.register(function() {});
+			var secondBinding = anEvent.register(function() {});
+			var thirdBinding = anotherEvent.register(function() {});
+			var fourthBinding = anotherEvent.register(function() {});
 
 			someEvents.dispose();
 
@@ -216,7 +203,7 @@ define(["src/events"], function(events) {
 		it("Event Manager keeps list of named event categories", function() {
 			var triggered = false;
 
-			events.at("c1").on("foo", function() {
+			events.at("c1").register("foo", function() {
 				triggered = true;
 			});
 			expect(!triggered).toBeTruthy();
@@ -229,6 +216,110 @@ define(["src/events"], function(events) {
 
 			events.at("c1").trigger("foo");
 			expect(triggered).toBeTruthy();
+		});
+	});
+
+	describe("deprecated", function() {
+		/* eslint-disable no-console */
+		var originalConsoleWarn;
+
+		beforeEach(function() {
+			console.warn = jasmine.createSpy("console.warn");
+		});
+
+		beforeAll(function() {
+			originalConsoleWarn = console.warn;
+		});
+
+		afterAll(function() {
+			console.warn = originalConsoleWarn;
+		});
+
+		it("on() method delegates to register", function() {
+			// Arrange: an event
+			var anEvent = events.event();
+			var spy = jasmine.createSpy("register");
+
+			anEvent.register = spy;
+			anEvent.on("foo");
+
+			expect(spy).toHaveBeenCalledWith("foo");
+			expect(console.warn).toHaveBeenCalled();
+		});
+
+		it("'using an event as a function' delegates to register", function() {
+			// Arrange: an event
+			var anEvent = events.event();
+			var spy = jasmine.createSpy("register");
+
+			anEvent.register = spy;
+			anEvent("foo");
+
+			expect(spy).toHaveBeenCalledWith("foo");
+			expect(console.warn).toHaveBeenCalled();
+		});
+
+		it("off() method delegates to unregister", function() {
+			// Arrange: an event
+			var anEvent = events.event();
+			var spy = jasmine.createSpy("unregister");
+
+			anEvent.unregister = spy;
+			anEvent.off("foo");
+
+			expect(spy).toHaveBeenCalledWith("foo");
+			expect(console.warn).toHaveBeenCalled();
+		});
+
+		it("onceOn() method delegates to registerOnce", function() {
+			// Arrange: an event
+			var anEvent = events.event();
+			var spy = jasmine.createSpy("registerOnce");
+
+			anEvent.registerOnce = spy;
+			anEvent.onceOn(spy);
+
+			expect(spy).toHaveBeenCalled();
+			expect(console.warn).toHaveBeenCalled();
+		});
+
+		it("on() category method delegates to register", function() {
+			// Arrange: an event
+			var someEvents = events.eventCategory();
+			var spy = jasmine.createSpy("register");
+
+			someEvents.register = spy;
+
+			someEvents.on("namedEvent", "something else");
+
+			expect(spy).toHaveBeenCalledWith("namedEvent", "something else");
+			expect(console.warn).toHaveBeenCalled();
+		});
+
+		it("off() category method delegates to unregister", function() {
+			// Arrange: an event
+			var someEvents = events.eventCategory();
+			var spy = jasmine.createSpy("unregister");
+
+			someEvents.unregister = spy;
+
+			someEvents.off("namedEvent", "something else");
+
+			expect(spy).toHaveBeenCalledWith("namedEvent", "something else");
+			expect(console.warn).toHaveBeenCalled();
+		});
+
+		it("onceOn() category method delegates to registerOnce", function() {
+			// Arrange: an event
+			var someEvents = events.eventCategory();
+			var spy = jasmine.createSpy("registerOnce");
+
+			someEvents.registerOnce = spy;
+
+			someEvents.onceOn("namedEvent", "something else");
+
+			expect(spy).toHaveBeenCalledWith("namedEvent", "something else");
+			expect(console.warn).toHaveBeenCalled();
 		});
 	});
 });

--- a/test/router/hashLocationTest.js
+++ b/test/router/hashLocationTest.js
@@ -116,7 +116,7 @@ define([
 
 			// Arrange: listen for url changes
 			var capturedUrl;
-			anotherHashLocation.onChanged(function(url) {
+			anotherHashLocation.changed.register(function(url) {
 				capturedUrl = url;
 				done();
 			});

--- a/test/router/routerTest.js
+++ b/test/router/routerTest.js
@@ -49,7 +49,7 @@ define([
 			// Arrange a router with options set
 			var anotherMy = {};
 			router({
-				locationHandler: {isFake: true, onChanged: function() {}}
+				locationHandler: {isFake: true, changed: {register: function() {}}}
 			}, anotherMy);
 
 			// Assert that options where applied

--- a/test/widgetTest.js
+++ b/test/widgetTest.js
@@ -68,7 +68,7 @@ define([
 			})();
 
 			// Assert: that callback is executed when
-			aWidget.on("anEvent", function() {
+			aWidget.register("anEvent", function() {
 				expect(true).toBeTruthy();
 			});
 
@@ -83,7 +83,7 @@ define([
 				var my = {};
 				var that = widgetSubclass({}, my);
 
-				that.onAnEvent = my.events.createEvent("anEvent");
+				that.anEvent = my.events.createEvent("anEvent");
 
 				that.aMethod = function() {
 					that.trigger("anEvent");
@@ -92,13 +92,15 @@ define([
 				return that;
 			})();
 
+			var spy = jasmine.createSpy("callback");
+
 			// Assert: that callback is executed when
-			aWidget.onAnEvent(function() {
-				expect(true).toBeTruthy();
-			});
+			aWidget.anEvent.register(spy);
 
 			// event is triggered
 			aWidget.aMethod();
+
+			expect(spy).toHaveBeenCalled();
 		});
 
 		it("linkTo() creates links to paths in app", function() {


### PR DESCRIPTION
This patch applies the following rewrites while creating the new methods and deprecating the old
ones:
* event() ⇒ event.register()
* event.on() ⇒ event.register()
* event.off() ⇒ event.unregister()
* event.onceOn() ⇒ event.registerOnce()
* eventCategory.on() ⇒ eventCategory.register()
* eventCategory.off() ⇒ eventCategory.unregister()
* eventCategory.onceOn() ⇒ eventCategory.registerOnce()

---

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/widgetjs/49)
<!-- Reviewable:end -->
