### PR TITLE
Revert "Rename the project to widget-js as widgetjs is already on npmjs.com"

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "widget-js",
+  "name": "widgetjs",
   "description": "A framework for building JavaScript applications with widgets.",
   "version": "3.0.0",
   "homepage": "http://github.com/foretagsplatsen/widgetjs",


### PR DESCRIPTION
This reverts commit 677a7749c2cc3330e223045ffddd5c2cd818d1b0. In fact,
npm does not allow too similar names so widget-js is not good
either. We decided not to put widgetjs on npmjs for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/widgetjs/73)
<!-- Reviewable:end -->
