### PR TITLE
Prevent registering the same callback to an event

### DIFF
--- a/src/events.js
+++ b/src/events.js
@@ -36,7 +36,9 @@ define([], function() {
 		};
 
 		/**
-		 * Binds callback to event. The callback will be invoked whenever the event is fired.
+		 * Binds callback to event. The callback will be invoked
+		 * whenever the event is fired. Avoid adding the same callback
+		 * twice.
 		 *
 		 * @param callback {function}
 		 * @returns {eventBinding}
@@ -96,6 +98,17 @@ define([], function() {
 				if (callback) {
 					callback.apply(that, params);
 				}
+			};
+
+			/**
+			 * Returns true if and only if the receiver is triggering
+			 * the callback given as parameter.
+			 *
+			 * @param cb {function} callback to test against
+			 * @returns {boolean}
+			 */
+			that.isForCallback = function(cb) {
+				return callback === cb;
 			};
 
 			return that;
@@ -190,14 +203,25 @@ define([], function() {
 		};
 
 		/**
-		 * Create and add callback binding to event
+		 * Create and add callback binding to the receiver. Avoid
+		 * adding the same callback twice.
 		 *
 		 * @param callback
 		 * @returns {eventBinding}
 		 */
 		function bindCallback(callback) {
-			var binding = eventBinding({callback: callback, event: that});
+			var binding = bindings.filter(function(binding) {
+				return binding.isForCallback(callback);
+			})[0];
+
+			// Don't register the same callback twice:
+			if (binding) {
+				return binding;
+			}
+
+			binding = eventBinding({callback: callback, event: that});
 			bindings.push(binding);
+
 			return binding;
 		}
 

--- a/src/test/eventsTest.js
+++ b/src/test/eventsTest.js
@@ -21,11 +21,45 @@ define([
 		it("Bind multiple callbacks to an event", function() {
 			// Arrange: an event
 			var anEvent = events.event();
+			var spy1 = jasmine.createSpy("callback1");
+			var spy2 = jasmine.createSpy("callback2");
+
+			// Act: bind two callbacks and trigger event
+			anEvent.register(spy1);
+			anEvent.register(spy2);
+
+			anEvent.trigger();
+
+			// Assert: that both where executed
+			expect(spy1).toHaveBeenCalledTimes(1);
+			expect(spy2).toHaveBeenCalledTimes(1);
+		});
+
+		it("Bind same callback only once", function() {
+			// Arrange: an event
+			var anEvent = events.event();
+
 			var spy = jasmine.createSpy("callback");
 
 			// Act: bind two callbacks and trigger event
 			anEvent.register(spy);
 			anEvent.register(spy);
+
+			anEvent.trigger();
+
+			// Assert: that both where executed
+			expect(spy).toHaveBeenCalledTimes(1);
+		});
+
+		it("Bind same callback with anonymous functions", function() {
+			// Arrange: an event
+			var anEvent = events.event();
+
+			var spy = jasmine.createSpy("callback");
+
+			// Act: bind two callbacks and trigger event
+			anEvent.register(function() {spy();});
+			anEvent.register(function() {spy();});
 
 			anEvent.trigger();
 


### PR DESCRIPTION
When calling event.register(callback) twice, the event will only
remember one callback. This is the same behavior as
addEventListener():
https://developer.mozilla.org/en-US/docs/Web/API/EventTarget/addEventListener#Multiple_identical_event_listeners

If you really want to register the same more than once, do it with an
anonymous function like this: event.register(() => callback()).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/widgetjs/74)
<!-- Reviewable:end -->
