### PR TITLE
B2253900612: Detach widget before updating it

### DIFF
--- a/src/Widget2.js
+++ b/src/Widget2.js
@@ -410,6 +410,7 @@ export default class Widget2 {
 			return;
 		}
 
+		this.willDetach();
 		this._willUpdate();
 		this._withAttachHooks(() => {
 			// clear content of root

--- a/src/widget.js
+++ b/src/widget.js
@@ -409,6 +409,7 @@ var widget = klassified.object.subclass(function(that, my) {
 			return;
 		}
 
+		that.willDetach();
 		my.willUpdate();
 		my.withAttachHooks(function() {
 			// clear content of root


### PR DESCRIPTION
When a widget is updated before calling willDetach(), some of its
children will never call willDetach(). This results in some popups being
stuck in the DOM without the ability to close them.

This fix calls willDetach() before updating a widget.

[Basecamp Bug](https://3.basecamp.com/4201305/buckets/11571123/todos/2253900612)