### PR TITLE
Decompose Widget.renderRootOn() to facilitate overriding

### DIFF
--- a/src/Widget2.js
+++ b/src/Widget2.js
@@ -302,27 +302,14 @@ export default class Widget2 {
 	}
 
 	/**
-	 * Main entry point for rendering. For convenience "renderOn" will    wrap the content
-	 * rendered by "renderContentOn" in a root element (renderRootOn) that will be matched
-	 * by asJQuery.
+	 * Main entry point for rendering. For convenience "renderOn" will
+	 * wrap the content rendered by "renderContentOn" in a root
+	 * element (renderRootOn) that will be matched by asJQuery.
 	 *
-	 * Usually concrete widgets override "renderContentOn" to render it content. Widgets
-	 * can override "renderOn" but must then make sure that it can be matched by "asJQuery".
-	 *
-	 * One way to do that is to make sure to have only one root element and setting the ID of
-	 * that element to the ID of the widget.
-	 *
-	 * @example
-	 *
-	 *        renderOn(html) {
-	 *			html.ul({id: that.getId()}
-	 *				html.li("BMW"),
-	 *				html.li("Toyota")
-	 *			);
-	 *		};
-	 *
-	 *
-	 * @param html
+	 * Usually concrete widgets override "renderContentOn" to render
+	 * its content instead of `renderOn`. It is also possible for
+	 * widgets to override `_makeRootTagOn` if they don't want the
+	 * `<widgetjs-widget>` tag.
 	 */
 	renderOn(html) {
 		// Renders widget by wrapping `renderContentOn()` in a root element.
@@ -355,7 +342,11 @@ export default class Widget2 {
 	 * @returns {htmlBrush}
 	 */
 	_renderRootOn(html) {
-		return html.tag("widgetjs-widget").id(this._id);
+		return this._makeRootTagOn(html).id(this._id);
+	}
+
+	_makeRootTagOn(html) {
+		return html.tag("widgetjs-widget");
 	}
 
 	/**

--- a/src/test/tests.js
+++ b/src/test/tests.js
@@ -1,5 +1,6 @@
 import "./htmlCanvasTest";
 import "./widgetTest";
+import "./widget2Test";
 import "./router/hashLocationTest";
 import "./router/routerTest";
 import "./router/routeTest";

--- a/src/test/widget2Test.js
+++ b/src/test/widget2Test.js
@@ -1,0 +1,64 @@
+import Widget from "../Widget2";
+import htmlCanvas from "../htmlCanvas";
+
+let sandboxId = "sandbox";
+
+describe("Widget2", () => {
+	describe("_makeRootTagOn()", () => {
+		class MyWidget extends Widget {
+			_initialize({tagName = "div", attributeName = "data-test", attributeValue = "foo"} = {}) {
+				super._initialize(...arguments);
+
+				this._tagName = tagName;
+				this._attributeName = attributeName;
+				this._attributeValue = attributeValue;
+			}
+
+			renderContentOn(html) {}
+
+			_makeRootTagOn(html) {
+				return html.tag(this._tagName, {[this._attributeName]: this._attributeValue});
+			}
+
+		}
+
+		it("allows for changing the root tag", () => {
+			withCanvas((html) => {
+				let tagName = "TR";
+				let attributeName = "data-test";
+				let attributeValue = "foo-bar";
+
+				let widget = new MyWidget({tagName, attributeName, attributeValue});
+
+				html.render(widget);
+
+				let result = html.root.element.firstElementChild;
+
+				expect(result.tagName).toEqual(tagName);
+				expect(result.getAttribute(attributeName)).toEqual(attributeValue);
+			});
+		});
+
+		it("assigns the widget's ID", () => {
+			withCanvas((html) => {
+				let widget = new MyWidget();
+
+				html.render(widget);
+
+				let result = html.root.element.firstElementChild;
+
+				expect(result.id).toEqual(widget.getId());
+			});
+		});
+	});
+});
+
+function withCanvas(callback) {
+	$("BODY").append(`<div id="${sandboxId}"></div>`);
+	var sandbox = jQuery(`#${sandboxId}`);
+
+	var html = htmlCanvas(sandbox);
+	callback(html);
+
+	sandbox.remove();
+}


### PR DESCRIPTION
With this decomposition, widgets can just override `_makeRootTagOn()`
when they want to control the root tag and not get "widgetjs-widget".

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/widgetjs/185)
<!-- Reviewable:end -->
