### PR TITLE
Don't emit falsy attributes

### DIFF
--- a/src/htmlCanvas.js
+++ b/src/htmlCanvas.js
@@ -486,6 +486,10 @@ TagBrushConstructor.prototype.attr = function(object) {
 };
 
 TagBrushConstructor.prototype.addAttribute = function(key, value) {
+	if (!value) {
+		return;
+	}
+
 	// Attach functions
 	if (typeof value === "function") {
 		this.on(key, value);

--- a/src/htmlCanvas.js
+++ b/src/htmlCanvas.js
@@ -479,19 +479,23 @@ TagBrushConstructor.prototype.css = function(key, value) {
 TagBrushConstructor.prototype.attr = function(object) {
 	for (var key in object) {
 		if (Object.prototype.hasOwnProperty.call(object, key)) {
-			// Attach functions
-			if (typeof object[key] === "function") {
-				this.on(key, object[key]);
-			}
-
-			else if (key === "klass" || key === "class") {
-				this.element.className = classNames(object[key]);
-			} else {
-				this.setAttribute(key, object[key]);
-			}
+			this.addAttribute(key, object[key]);
 		}
 	}
 	return this;
+};
+
+TagBrushConstructor.prototype.addAttribute = function(key, value) {
+	// Attach functions
+	if (typeof value === "function") {
+		this.on(key, value);
+	}
+
+	else if (key === "klass" || key === "class") {
+		this.element.className = classNames(value);
+	} else {
+		this.setAttribute(key, value);
+	}
 };
 
 /**

--- a/src/test/htmlCanvasTest.js
+++ b/src/test/htmlCanvasTest.js
@@ -85,21 +85,23 @@ describe("htmlCanvas", function() {
 		});
 	});
 
-	it("can omit attributes", () => {
-		withCanvas((html) => {
-			// Arrange: a div with attributes
-			html.div({
-				id: "test_div",
-				"special_attribute": html.omit()
-			}, "content");
+	describe("should omit an attribute", () => {
+		it("when value is html.omit()", () => {
+			withCanvas((html) => {
+				// Arrange: a div with attributes
+				html.div({
+					id: "test_div",
+					"special_attribute": html.omit()
+				}, "content");
 
-			// Assert: that DIV was rendered
-			var divEl = jQuery("#test_div");
+				// Assert: that DIV was rendered
+				var divEl = jQuery("#test_div");
 
-			expect(divEl.get(0)).toBeTruthy();
+				expect(divEl.get(0)).toBeTruthy();
 
-			// and class was set
-			expect(!divEl.is("[special_attribute]")).toBeTruthy();
+				// and class was set
+				expect(!divEl.is("[special_attribute]")).toBeTruthy();
+			});
 		});
 	});
 

--- a/src/test/htmlCanvasTest.js
+++ b/src/test/htmlCanvasTest.js
@@ -103,6 +103,46 @@ describe("htmlCanvas", function() {
 				expect(!divEl.is("[special_attribute]")).toBeTruthy();
 			});
 		});
+
+		it("when value is undefined", () => {
+			withCanvas((html) => {
+				let attributeName = "data-test";
+
+				let div = html.div({[attributeName]: undefined});
+
+				expect(div.element.hasAttribute("data-test")).toBeFalse();
+			});
+		});
+
+		it("when value is null", () => {
+			withCanvas((html) => {
+				let attributeName = "data-test";
+
+				let div = html.div({[attributeName]: null});
+
+				expect(div.element.hasAttribute("data-test")).toBeFalse();
+			});
+		});
+
+		it("when value if false", () => {
+			withCanvas((html) => {
+				let attributeName = "data-test";
+
+				let div = html.div({[attributeName]: false});
+
+				expect(div.element.hasAttribute("data-test")).toBeFalse();
+			});
+		});
+
+		it("when value is the empty string", () => {
+			withCanvas((html) => {
+				let attributeName = "data-test";
+
+				let div = html.div({[attributeName]: ""});
+
+				expect(div.element.hasAttribute("data-test")).toBeFalse();
+			});
+		});
 	});
 
 	it("callbacks can be attached to events", () => {


### PR DESCRIPTION
Breaking change. Before, this JS code:

```js
html.div({ class: "btn", "data-test": undefined }, "Click me");
```

would trigger:

```html
<div class="btn" data-test="undefined">Click me</div>
```

After this PR is merged, a falsy attribute won't be added to the DOM anymore:

```html
<div class="btn">Click me</div>
```

This both makes the DOM cleaner and makes it possible to simplify the JS.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/widgetjs/240)
<!-- Reviewable:end -->
