### PR TITLE
32129139: Wrap 3rd-party libraries that don't have any ES export

### DIFF
--- a/src/Widget2.js
+++ b/src/Widget2.js
@@ -1,7 +1,7 @@
 import router from "./router.js";
 import { eventCategory } from "yaem";
 import htmlCanvas from "./htmlCanvas.js";
-import jQuery from "jquery";
+import jQuery from "./lib-wrappers/jquery.js";
 import { getCurrentWidget, withCurrentWidget } from "./currentWidget.js";
 import { newId } from "./idGenerator.js";
 

--- a/src/htmlCanvas.js
+++ b/src/htmlCanvas.js
@@ -1,5 +1,5 @@
-import jQuery from "jquery";
-import classNames from "classnames";
+import jQuery from "./lib-wrappers/jquery.js";
+import classNames from "./lib-wrappers/classnames.js";
 
 /**
  * @typedef {function} renderer

--- a/src/lib-wrappers/README.md
+++ b/src/lib-wrappers/README.md
@@ -1,0 +1,2 @@
+This directory contains a JS module for each external library that
+doesn't provide any ES module.

--- a/src/lib-wrappers/classnames.js
+++ b/src/lib-wrappers/classnames.js
@@ -1,0 +1,3 @@
+import "classnames";
+
+export default window.classNames;

--- a/src/lib-wrappers/jquery.js
+++ b/src/lib-wrappers/jquery.js
@@ -1,0 +1,3 @@
+import "jquery";
+
+export default window.jquery;

--- a/src/router/hashLocation.js
+++ b/src/router/hashLocation.js
@@ -1,4 +1,4 @@
-import jQuery from "jquery";
+import jQuery from "../lib-wrappers/jquery.js";
 import { eventCategory } from "yaem";
 import url from "./url.js";
 import { object } from "klassified";

--- a/src/widget.js
+++ b/src/widget.js
@@ -3,7 +3,7 @@ import widgetExtensions from "./widget-extensions.js";
 import router from "./router.js";
 import { eventCategory } from "yaem";
 import htmlCanvas from "./htmlCanvas.js";
-import jQuery from "jquery";
+import jQuery from "./lib-wrappers/jquery.js";
 import { getCurrentWidget, withCurrentWidget } from "./currentWidget.js";
 import { newId } from "./idGenerator.js";
 


### PR DESCRIPTION
The line

  import jQuery from "jquery";

implies that the library "jquery" has a default export. This is
not the case and the line above only works because we use Webpack.

This commit wraps each library that do not export an ES-module.

Basecamp: https://3.basecamp.com/4201305/buckets/32129139/todos/7253917413

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/widgetjs/476)
<!-- Reviewable:end -->
