### PR TITLE
32129139: Configure .editorconfig to treat .mjs and .cjs just like .js files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,7 +6,7 @@ trim_trailing_whitespace=true
 charset=utf-8
 indent_style=space
 
-[*.js]
+[*.{js,cjs,mjs}]
 indent_style=tab
 indent_size=4
 


### PR DESCRIPTION
https://3.basecamp.com/4201305/buckets/32129139/todos/7278550647

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/foretagsplatsen/widgetjs/484)
<!-- Reviewable:end -->
